### PR TITLE
add optional support for heinleins spamassassin rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories \
 && cd /tmp && rm -Rf ./*
 
 WORKDIR /usr/local/bin
-COPY travis-helpers/set-timezone.sh entrypoint.sh update_bazaar.sh ./
+COPY travis-helpers/set-timezone.sh entrypoint.sh update_bazaar.sh update_sa_heinlein.sh update_sa_heinlein_daemon.sh ./
 
 WORKDIR /etc/rspamd/local.d
 COPY local.conf ./

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Abuse.ch, the Malware Bazaar hashes are downloaded every BZSLEEP hours if set,
 minimum is 1 hour as they are updated every hour.
 See [here](https://bazaar.abuse.ch/).
 
+Spamassassin rules from heinlein-support.de are loaded every HLSLEEP hours if set. They include
+regularly updated spamassassin filter rules, mainly for German spam.
+If the rules changed after the update, rspamd is restarted automatically via SIGHUP.
+See [here](https://www.heinlein-support.de/blog/news/aktuelle-spamassassin-regeln-von-heinlein-support/) for a
+more detailed description in German.
+
 The [url_redirector](https://rspamd.com/doc/modules/url_redirector.html) module
 is configured to read domain names from local.d/maps.d/redirectors.inc
 This can be copied from the main rspamd config into local.d/maps.d if SYSREDIR
@@ -55,6 +61,7 @@ Github Repository: [https://github.com/a16bitsysop/docker-rspamd](https://github
 | DNSSEC    | enable dnssec for dns lookups.                         | no dnssec          |
 | NOGREY    | disable greylisting (soft reject).                     | greylist           |
 | BZSLEEP   | hours between updates of abuse.ch hashes eg 1.5        | unset / disabled   |
+| HLSLEEP   | hours between updates of heinleins spamassassin rules  | unset / disabled   |
 | SYSREDIR  | copy rsypamd redirectors.inc for url_redirector to use | unset / don't copy |
 | TIMEZONE  | timezone to use inside the container, eg Europe/London | unset              |
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,7 @@ echo "\$CONTROLIP= $CONTROLIP"
 echo "\$DNSSEC= $DNSSEC"
 echo "\$NOGREY= $NOGREY"
 echo "\$BZSLEEP= $BZSLEEP"
+echo "\$HLSLEEP= $HLSLEEP"
 echo "\$SYSREDIR= $SYSREDIR"
 echo
 
@@ -79,6 +80,17 @@ fi
 
 # start update abuse.ch malware bazaar hashes
 [ -n "$BZSLEEP" ] && su rspamd -s /bin/sh -c "update_bazaar.sh" &
+
+# update heinlein rules once & start daemon to update them in the background
+if [ -n "$HLSLEEP" ]
+then
+  echo 'ruleset = "/etc/rspamd/custom/sa-rules";' > spamassassin.conf
+  mkdir /etc/rspamd/custom/
+  /usr/local/bin/update_sa_heinlein.sh
+  /usr/local/bin/update_sa_heinlein_daemon.sh &
+else
+  rm -f spamassassin.conf
+fi
 
 if [ -n "$CLAMAV" ]
 then

--- a/update_sa_heinlein.sh
+++ b/update_sa_heinlein.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Inspired by https://github.com/mailcow/mailcow-dockerized/blob/master/data/Dockerfiles/dovecot/sa-rules.sh
+
+set -e
+
+# Create temp directories
+[[ ! -d /tmp/sa-rules-heinlein ]] && mkdir -p /tmp/sa-rules-heinlein
+
+echo "Updating heinlein rules"
+# Hash current SA rules
+if [[ ! -f /etc/rspamd/custom/sa-rules ]]; then
+  HASH_SA_RULES=0
+else
+  HASH_SA_RULES=$(cat /etc/rspamd/custom/sa-rules | md5sum | cut -d' ' -f1)
+fi
+
+# Deploy
+url="http://www.spamassassin.heinlein-support.de/$(drill 1.4.3.spamassassin.heinlein-support.de txt | grep ^1.4.3.spamassassin.heinlein-support.de | cut -d\" -f2).tar.gz"
+echo "Updating from $url"
+wget "$url" -O /tmp/sa-rules-heinlein.tar.gz
+if gzip -t /tmp/sa-rules-heinlein.tar.gz; then
+  tar xfvz /tmp/sa-rules-heinlein.tar.gz -C /tmp/sa-rules-heinlein
+  cat /tmp/sa-rules-heinlein/*cf > /etc/rspamd/custom/sa-rules
+fi
+
+sed -i -e 's/\([^\\]\)\$\([^\/]\)/\1\\$\2/g' /etc/rspamd/custom/sa-rules
+
+# restart rspamd with SIGHUP if hash changed
+if [[ "$(cat /etc/rspamd/custom/sa-rules | md5sum | cut -d' ' -f1)" != "${HASH_SA_RULES}" ]]; then
+  echo "Restarting rspamd"
+  killall -SIGHUP rspamd || true
+fi
+
+# Cleanup
+rm -rf /tmp/sa-rules-heinlein /tmp/sa-rules-heinlein.tar.gz
+
+echo "Heinlein rules updated"

--- a/update_sa_heinlein_daemon.sh
+++ b/update_sa_heinlein_daemon.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+while true; do
+  ZZZ="${HLSLEEP-1}"
+  ZZZ="$(echo "if ($ZZZ < 1) 1 else $ZZZ" | bc -l)"
+  sleep "$ZZZ"h
+
+  /usr/local/bin/update_sa_heinlein.sh
+done


### PR DESCRIPTION
Hi @a16bitsysop,

thanks for providing this pre-configured and multiplatform-enabled rspamd image!

This PR adds support for additional spamassassin rules provided by heinlein-support.de. They host the popular provider mailbox.org and their rules are mainly targeted towards German spam. Some international rules are also included though.
I added bind-tools to use dig to query for the most recent version and a script that downloads & extracts the rules and writes them to a location configured in rspamd. Rspamd is restarted via SIGHUP if the rules changed.

The whole thing is optional and only enabled if HLSLEEP is set.

Thanks!

